### PR TITLE
Support repos cloned without '.git' suffix

### DIFF
--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -49,16 +49,16 @@ function! s:execute_with_commit(commit, startline, endline)
 endfunction
 
 function! s:get_repo_url_from_git_protocol(uri)
-    let s:matches = matchlist(a:uri, '^git@\(.*\):\(.*\).git')
+    let s:matches = matchlist(a:uri, '^git@\(.*\):\(.*\)\(.git\)\=')
     return "https://" . s:matches[1] .'/' . s:matches[2]
 endfunction
 
 function! s:get_repo_url_from_ssh_protocol(uri)
-    let s:matches = matchlist(a:uri, '^ssh:\/\/git@\(.\{-\}\)\/\(.*\).git')
+    let s:matches = matchlist(a:uri, '^ssh:\/\/git@\(.\{-\}\)\/\(.*\)\(.git\)\=')
     return "https://" . s:matches[1] .'/' . s:matches[2]
 endfunction
 
 function! s:get_repo_url_from_https_protocol(uri)
-    let s:matches = matchlist(a:uri, '^\(.*\).git')
+    let s:matches = matchlist(a:uri, '^\(.*\)\(.git\)\=')
     return s:matches[1]
 endfunction


### PR DESCRIPTION
If the repo is cloned without the .git suffix, git reports the repo without the suffix, which causes the regexps not to match in URL extraction. This change makes the final .git optional.